### PR TITLE
Fix variable enclosure in /etc/hosts check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,4 +37,4 @@
     regexp: "{{item.regexp}}"
     line: "{{item.line}}"
     state: present
-  with_items: hostname_hosts_file
+  with_items: "{{ hostname_hosts_file }}"


### PR DESCRIPTION
In "Ensure hostname entries in /etc/hosts", the hostname_hosts_file is not properly enclosed for Ansible 2